### PR TITLE
Make clickable area of icons bigger to increase usability

### DIFF
--- a/src/styles/audio-recorder.css
+++ b/src/styles/audio-recorder.css
@@ -9,7 +9,6 @@
     display: flex;
     align-items: center;
 
-    padding: 12px 12px;
     transition: all 0.2s ease-in;
 }
 
@@ -17,6 +16,15 @@
     cursor: pointer;
     height: 16px;
     color: black;
+    padding: 12px;
+}
+
+.audio-recorder .audio-recorder-mic {
+    border-radius: 20px;
+}
+
+.audio-recorder.recording .audio-recorder-mic {
+    border-radius: 0;
 }
 
 .audio-recorder-timer, .audio-recorder-status {
@@ -47,8 +55,12 @@
 
 .audio-recorder-options {
     height: 16px;
-    margin-left: 10px;
     cursor: pointer;
+    padding: 12px 6px 12px 12px;
+}
+.audio-recorder-options ~ .audio-recorder-options {
+    padding: 12px 12px 12px 6px;
+    border-radius: 0 5px 5px 0;
 }
 
 .recording {


### PR DESCRIPTION
Hi @samhirtarif,

thank you for your react-audio-recorder package. It works like a charm.

I think it can be even better if the click-able areas are bigger. Here is my proposal how this can be done.

_The red borders in the images are only there to visualize the change. They are not part of the code_

**BEFORE:**
<img width="75" alt="Screenshot 2023-03-18 at 11 42 38" src="https://user-images.githubusercontent.com/451298/226100973-ce7afdf8-a25b-4f1e-982b-32d2e38db077.png">
<img width="317" alt="Screenshot 2023-03-18 at 11 42 45" src="https://user-images.githubusercontent.com/451298/226100979-0850cc3f-fed4-477c-91a9-1e011f0afa8f.png">

**AFTER:**
<img width="66" alt="Screenshot 2023-03-18 at 11 40 56" src="https://user-images.githubusercontent.com/451298/226101039-2331968b-6a0a-401a-937d-4e1c90c5f3e8.png">
<img width="343" alt="Screenshot 2023-03-18 at 11 41 06" src="https://user-images.githubusercontent.com/451298/226101044-21d8528d-520c-4d57-8b11-5d57514550df.png">

Your code made this change simple, thank you for that as well. 🙂 
All the tests are still green.

